### PR TITLE
Feature/init terraform docs diagram scripts

### DIFF
--- a/scripts/generar_diagrama.py
+++ b/scripts/generar_diagrama.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""
+scripts/generar_diagrama.py
+- Genera docs/diagrama_red.dot a partir de los .tfstate en cada módulo
+"""
+import os
+import json
+
+def generate_dot():
+    """
+    Lee terraform.tfstate de cada módulo (iac/<módulo>/terraform.tfstate)
+    y extrae dependencies para formar un grafo DOT.
+    """
+    # TODO: implementar lectura de JSON y generar líneas DOT
+    return
+
+def main():
+    # TODO: invocar generate_dot() y escribir docs/diagrama_red.dot
+    pass
+
+if __name__ == "__main__":
+    main() 

--- a/scripts/terraform_docs.py
+++ b/scripts/terraform_docs.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""
+scripts/terraform_docs.py
+Recorre cada módulo en iac/ y genera archivos Markdown en docs/<módulo>.md
+"""
+import os
+import re
+import json
+
+def parse_variables(modulo_path):
+    """
+    Lee variables.tf y extrae nombre, tipo, default y descripción.
+    """
+    # TODO: implementar parsing con regex
+    return []
+
+def parse_outputs(modulo_path):
+    """
+    Lee outputs.tf y extrae nombre y descripción.
+    """
+    # TODO: implementar parsing con regex
+    return []
+
+def parse_resources(modulo_path):
+    """
+    Lee main.tf y extrae recursos (tipo, nombre).
+    """
+    # TODO: implementar parsing con regex
+    return []
+
+def write_markdown(modulos):
+    """
+    Por cada módulo, escribe docs/<módulo>.md con:
+    - Encabezado
+    - Descripción placeholder (100 palabras)
+    - Tabla de variables
+    - Tabla de outputs
+    - Lista de recursos
+    """
+    # TODO: recorrer lista de módulos y generar Markdown
+    pass
+
+def main():
+    root = os.path.join(os.path.dirname(__file__), "../iac")
+    # TODO: detectar carpetas de módulo y llamar a parse_*/write_markdown
+    pass
+
+if __name__ == "__main__":
+    main() 


### PR DESCRIPTION
Este PR añade esqueletos ejecutables para `scripts/terraform_docs.py` y `scripts/generar_diagrama.py`, cada uno con sus importaciones correspondientes, y define las funciones vacías requeridas: `parse_variables()`, `parse_outputs()`, `parse_resources()` y `write_markdown()` en `terraform_docs.py`, y `generate_dot()` en `generar_diagrama.py`, todas marcadas con `# TODO` para su implementación futura.
