### PR TITLE
fix(network): Error when reproducing terraform plan due to variable of wrong type

### DIFF
--- a/iac/network/main.tf
+++ b/iac/network/main.tf
@@ -6,10 +6,10 @@ locals {
   cidr_newbits = ceil(log(local.numero_subredes, 2)) + 2
 
   subredes_publicas = [
-    for i in var.zonas_disponibilidad : cidrsubnet(var.vpc_cidr, local.cidr_newbits, i)
+    for i, zd in var.zonas_disponibilidad : cidrsubnet(var.vpc_cidr, local.cidr_newbits, i)
   ]
   subredes_privadas = [
-    for i in var.zonas_disponibilidad : cidrsubnet(var.vpc_cidr, local.cidr_newbits, i + length(var.zonas_disponibilidad))
+    for i, zd in var.zonas_disponibilidad : cidrsubnet(var.vpc_cidr, local.cidr_newbits, i + length(var.zonas_disponibilidad))
   ]
 
   costo_nat_gateway_total = var.permitir_nat_gateway ? length(var.zonas_disponibilidad) * 45.0 : 0.0


### PR DESCRIPTION
Se encontró un pequeño error al iterar entre los modulos de IaC manualmente mediante `terraform plan`, Especificamente, en el módulo network en su archivo ´main.tf´, se descubrió que no se estableció adecuadamente una variable de iteración para la creación simulada de subredes. Luego de una prueba con los cambios realizados, los resultados fueron satisfactorios, esperamos su pronta aprobación.