### PR TITLE
feat(py): implement parse_variables and parse_outputs in terraform_do…

### DIFF
--- a/docs/compute.md
+++ b/docs/compute.md
@@ -5,12 +5,15 @@ Descripción placeholder
 ## Tabla de variables:
 | Nombre | Tipo | Default | Descripción |
 |--------|------|---------|-------------|
-
+| tipo_instancia | string | "pequeño" | Tipo/tamaño de instancia computacional según proveedor |
+| ids_subred | list(string) | ["1234", "2345", "3456"] | Lista de ids de subredes donde los recursos computacionales serán desplegados |
 
 ## Tabla de outputs:
 | Nombre | Descripción |
 |--------|-------------|
-
+| id_config_computacional | Identificador del recurso computacional creado con null resource |
+| prefix_recurso | Prefijo generado para el recurso de computo |
+| resumen_recurso | Un resumen de la configuración del módulo de cómputo |
 
 ## Lista de recursos:
 1. "null_resource" "config_compute" 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -5,12 +5,16 @@ Descripción placeholder
 ## Tabla de variables:
 | Nombre | Tipo | Default | Descripción |
 |--------|------|---------|-------------|
-
+| dias_retencion_logs | number | 30 | Número de días de retención de log de aplicación |
+| nivel_log | string | "INFO" | Nivel mínimo de logging definido para los logs de aplicación |
+| permite_auditoria_logs | bool | false | Permite la auditoria de logs para el cumplimiento de requerimientos |
 
 ## Tabla de outputs:
 | Nombre | Descripción |
 |--------|-------------|
-
+| id_config_logging | Identificador único de la configuración de logging creado por null resource |
+| grupos_log | Lista de grupos log a crearse |
+| resumen_logging | Un resumen de la configuración de logging |
 
 ## Lista de recursos:
 1. "null_resource" "config_logging" 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -5,12 +5,16 @@ Descripción placeholder
 ## Tabla de variables:
 | Nombre | Tipo | Default | Descripción |
 |--------|------|---------|-------------|
-
+| permite_monitoreo | bool | true | Permite un monitoreo detallado con alarmas |
+| email_alertas | string | N/A | Dirección de email para recibir alertas por monitoreo |
+| dias_retencion_metricas | number | 90 | Número de días de retención de métricas de recursos |
 
 ## Tabla de outputs:
 | Nombre | Descripción |
 |--------|-------------|
-
+| id_config_monitoreo | Identificador único de la configuración de monitorización creado por null resource |
+| config_alertas | Detalles de configuración para alertas de monitoreo |
+| estimacion_costo | Estimado del costo total por días de monitoreo |
 
 ## Lista de recursos:
 1. "null_resource" "config_monitoreo" 

--- a/docs/network.md
+++ b/docs/network.md
@@ -5,12 +5,16 @@ Descripción placeholder
 ## Tabla de variables:
 | Nombre | Tipo | Default | Descripción |
 |--------|------|---------|-------------|
-
+| vpc_cidr | string | "10.0.0.0/16" | Bloque CIDR declarada para una VPC(Virtual Private Cloud) |
+| zonas_disponibilidad | list(string) | N/A | Lista de zonas de disponibilidad a donde redistribuir los recursos existentes |
+| permitir_nat_gateway | bool | true | Habilitar Gateway NAT para permitir acceso a internet desde subredes privadas. |
 
 ## Tabla de outputs:
 | Nombre | Descripción |
 |--------|-------------|
-
+| id_config_red | Identificador único de la configuración de red creada por null resource |
+| resumen_red | Un resumen de la configuración del módulo de red |
+| direccion_subredes | Direcciones de subredes de CIDR por zona de disponibilidad |
 
 ## Lista de recursos:
 1. "null_resource" "red_config" 

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,12 +5,16 @@ Descripción placeholder
 ## Tabla de variables:
 | Nombre | Tipo | Default | Descripción |
 |--------|------|---------|-------------|
-
+| permite_encriptacion | bool | true | Permite encriptacion para todos los recursos disponibles |
+| bloques_CIDR_permitidos | list(string) | [] | Lista de bloques CIDR permitidos a tener acceso a recursos |
+| nivel_seguridad | string | "estandar" | Nivel de seguridad establecida (basico, estandar, alto, critico) |
 
 ## Tabla de outputs:
 | Nombre | Descripción |
 |--------|-------------|
-
+| id_config_seguridad | Identificador único de la configuración de seguridad creado por null resource |
+| resumen_seguridad | Un resumen de la configuración del módulo de seguridad |
+| requerimientos_politicas | Políticas de seguridad requeridas para el actual nivel de seguridad |
 
 ## Lista de recursos:
 1. "null_resource" "config_seguridad" 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -5,12 +5,16 @@ Descripción placeholder
 ## Tabla de variables:
 | Nombre | Tipo | Default | Descripción |
 |--------|------|---------|-------------|
-
+| tipo_almacenamiento | string | "rty" | Tipo de almacenamiento primario para consistencia de datos |
+| dias_backup | number | 7 | Número de días de retención de backups |
+| permite_versionado | bool | false | Permitir versionamiento para objetos almacenados |
 
 ## Tabla de outputs:
 | Nombre | Descripción |
 |--------|-------------|
-
+| id_config_almacenamiento | Identificador único de la configuración de almacenamiento creado por null resource |
+| resumen_almacenamiento | Un resumen de la configuración del módulo de almacenamiento |
+| proteccion_datos | Protección de datos y configuración de backups |
 
 ## Lista de recursos:
 1. "null_resource" "config_almacenamiento" 

--- a/scripts/terraform_docs.py
+++ b/scripts/terraform_docs.py
@@ -13,16 +13,142 @@ from string import Template
 def parse_variables(modulo_path):
     """
     Lee variables.tf y extrae nombre, tipo, default y descripción.
+    Retorna: [{ "name": str, "type": str, "default": str, "description": str }]
     """
-    # TODO: implementar parsing con regex
-    return []
+    variables_tf_path = os.path.join(modulo_path, "variables.tf")
+    
+    # Si no existe variables.tf, retorna lista vacía sin excepciones
+    if not os.path.exists(variables_tf_path):
+        return []
+    
+    try:
+        with open(variables_tf_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Regex para extraer bloques de variables completos
+        # Busca 'variable "nombre" {' hasta el cierre del bloque con '}'
+        # Usa un enfoque de conteo de llaves para manejar bloques anidados
+        variables = []
+        
+        # Patrón para encontrar el inicio de un bloque variable
+        variable_pattern = r'variable\s+"([^"]+)"\s*\{'
+        
+        # Encontrar todas las posiciones de inicio de variables
+        for match in re.finditer(variable_pattern, content):
+            var_name = match.group(1)
+            start_pos = match.end()
+            
+            # Encontrar el final del bloque contando llaves
+            brace_count = 1
+            end_pos = start_pos
+            
+            while end_pos < len(content) and brace_count > 0:
+                if content[end_pos] == '{':
+                    brace_count += 1
+                elif content[end_pos] == '}':
+                    brace_count -= 1
+                end_pos += 1
+            
+            # Extraer el contenido del bloque
+            block_content = content[start_pos:end_pos-1]
+            
+            # Extraer información específica del bloque
+            var_info = {
+                "name": var_name,
+                "type": "string",  # valor por defecto
+                "default": "N/A",  # valor por defecto
+                "description": "No description provided"  # valor por defecto
+            }
+            
+            # Extraer descripción
+            desc_match = re.search(r'description\s*=\s*"([^"]*)"', block_content)
+            if desc_match:
+                var_info["description"] = desc_match.group(1)
+            
+            # Extraer tipo
+            type_match = re.search(r'type\s*=\s*(\w+(?:\([^)]*\))?)', block_content)
+            if type_match:
+                var_info["type"] = type_match.group(1)
+            
+            # Extraer default (puede ser string, number, bool, list, etc.)
+            # Buscar diferentes formatos de default
+            default_match = re.search(r'default\s*=\s*([^}\n]*?)(?=\n|\s*validation|\s*$)', block_content, re.DOTALL)
+            if default_match:
+                default_value = default_match.group(1).strip()
+                # Limpiar el valor (remover comentarios y espacios extra)
+                default_value = re.sub(r'\s*#.*$', '', default_value, flags=re.MULTILINE)
+                default_value = default_value.strip()
+                if default_value:
+                    var_info["default"] = default_value
+            
+            variables.append(var_info)
+        
+        return variables
+    
+    except Exception as e:
+        # En caso de error al leer el archivo, retorna lista vacía
+        print(f"Error leyendo {variables_tf_path}: {e}")
+        return []
 
 def parse_outputs(modulo_path):
     """
     Lee outputs.tf y extrae nombre y descripción.
+    Retorna: [{ "name": str, "description": str }]
     """
-    # TODO: implementar parsing con regex
-    return []
+    outputs_tf_path = os.path.join(modulo_path, "outputs.tf")
+    
+    # Si no existe outputs.tf, retorna lista vacía sin excepciones
+    if not os.path.exists(outputs_tf_path):
+        return []
+    
+    try:
+        with open(outputs_tf_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Regex para extraer bloques de outputs completos
+        outputs = []
+        
+        # Patrón para encontrar el inicio de un bloque output
+        output_pattern = r'output\s+"([^"]+)"\s*\{'
+        
+        # Encontrar todas las posiciones de inicio de outputs
+        for match in re.finditer(output_pattern, content):
+            output_name = match.group(1)
+            start_pos = match.end()
+            
+            # Encontrar el final del bloque contando llaves
+            brace_count = 1
+            end_pos = start_pos
+            
+            while end_pos < len(content) and brace_count > 0:
+                if content[end_pos] == '{':
+                    brace_count += 1
+                elif content[end_pos] == '}':
+                    brace_count -= 1
+                end_pos += 1
+            
+            # Extraer el contenido del bloque
+            block_content = content[start_pos:end_pos-1]
+            
+            # Extraer información específica del bloque
+            output_info = {
+                "name": output_name,
+                "description": "No description provided"  # valor por defecto
+            }
+            
+            # Extraer descripción
+            desc_match = re.search(r'description\s*=\s*"([^"]*)"', block_content)
+            if desc_match:
+                output_info["description"] = desc_match.group(1)
+            
+            outputs.append(output_info)
+        
+        return outputs
+    
+    except Exception as e:
+        # En caso de error al leer el archivo, retorna lista vacía
+        print(f"Error leyendo {outputs_tf_path}: {e}")
+        return []
 
 def parse_resources(modulo_path):
     """


### PR DESCRIPTION
Este PR implementa el parser de variables y outputs en terraform_docs.py usando recorrido de bloques con conteo de llaves.

**Cambios principales**
- Añade parse_variables() y parse_outputs() que recorren el contenido y cuentan {} para extraer bloques anidados.
- Extrae nombre, tipo, default y descripción de variables; nombre y descripción de outputs.
- Retorna listas vacías si faltan variables.tf u outputs.tf sin lanzar errores.

**Lo que se logró**
- Parsing fiable ante validaciones anidadas ya que detecta bloques validation, lifecycle, etc., sin confundirse con llaves internas.
- Cobertura completa de módulos, cumple con los 6 módulos (network, compute, storage, security, logging, monitoring).
- Retorna estructuras compatibles con write_markdown() para generación automática de docs.

Aunque en la historia de usuario se menciona el uso de regex para toda la extracción, encontré un mejor enfoque para manejar los bloques anidados en las declaraciones de terraform. Se optó por el recorrido de bloques en vez de regex para garantizar extracción fiable ante anidamientos y comentarios, simplificando la extensión futura del parser.