### PR TITLE
fix(defaults): Add defaults values in variables for monitoring and

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -6,7 +6,7 @@ Descripción placeholder
 | Nombre | Tipo | Default | Descripción |
 |--------|------|---------|-------------|
 | permite_monitoreo | bool | true | Permite un monitoreo detallado con alarmas |
-| email_alertas | string | N/A | Dirección de email para recibir alertas por monitoreo |
+| email_alertas | string | "dummy123@gmail.com" | Dirección de email para recibir alertas por monitoreo |
 | dias_retencion_metricas | number | 90 | Número de días de retención de métricas de recursos |
 
 ## Tabla de outputs:

--- a/docs/network.md
+++ b/docs/network.md
@@ -6,7 +6,7 @@ Descripción placeholder
 | Nombre | Tipo | Default | Descripción |
 |--------|------|---------|-------------|
 | vpc_cidr | string | "10.0.0.0/16" | Bloque CIDR declarada para una VPC(Virtual Private Cloud) |
-| zonas_disponibilidad | list(string) | N/A | Lista de zonas de disponibilidad a donde redistribuir los recursos existentes |
+| zonas_disponibilidad | list(string) | ["Canada", "USA", "Australia", "Peru"] | Lista de zonas de disponibilidad a donde redistribuir los recursos existentes |
 | permitir_nat_gateway | bool | true | Habilitar Gateway NAT para permitir acceso a internet desde subredes privadas. |
 
 ## Tabla de outputs:

--- a/iac/monitoring/variables.tf
+++ b/iac/monitoring/variables.tf
@@ -7,6 +7,7 @@ variable "permite_monitoreo" {
 variable "email_alertas" {
   description = "Dirección de email para recibir alertas por monitoreo"
   type        = string
+  default     = "dummy123@gmail.com"
 
   validation {
     condition     = can(regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", var.email_alertas))

--- a/iac/network/variables.tf
+++ b/iac/network/variables.tf
@@ -12,6 +12,7 @@ variable "vpc_cidr" {
 variable "zonas_disponibilidad" {
   description = "Lista de zonas de disponibilidad a donde redistribuir los recursos existentes"
   type        = list(string)
+  default     = ["Canada", "USA", "Australia", "Peru"]
 
   validation {
     condition     = length(var.zonas_disponibilidad) >= 2

--- a/iac/security/main.tf
+++ b/iac/security/main.tf
@@ -1,3 +1,10 @@
+data "terraform_remote_state" "network" {
+  backend = "local"
+  config = {
+    path = "../network/terraform.tfstate"
+  }
+}
+
 locals {
   def_politica = {
     basico   = ["contraseña_requerida", "mfa_habilitado"]
@@ -17,7 +24,12 @@ resource "null_resource" "config_seguridad" {
     CIDR_permitidos      = join(", ", sort(var.bloques_CIDR_permitidos))
     nivel_seguridad      = var.nivel_seguridad
     security_hash        = local.hash_seguridad
+    network_config_id    = data.terraform_remote_state.network.outputs.id_config_red
   }
+
+  depends_on = [
+    data.terraform_remote_state.network
+  ]
 
   provisioner "local-exec" {
     command = <<-EOT


### PR DESCRIPTION
Con fines de demostración y ejecución rápida se cambiaron ligeramente los módulos definidos (monitoring y network) para definirles variables default donde faltasen. Así mismo, se añadió una dependencia unilateral mediante un bloque `data` de security con network para validar la funcionalidad de nuestra herramienta de documentación automatizada.  