### PR TITLE
Feature/enhanced diagram colors labels

### DIFF
--- a/docs/diagrama_red.dot
+++ b/docs/diagrama_red.dot
@@ -1,0 +1,11 @@
+digraph G {
+rankdir=LR
+    "null_resource.config_almacenamiento" [label="null_resource.config_almacenamiento", color=orange]
+    "terraform_remote_state.network" [label="terraform_remote_state.network", color=red]
+    "null_resource.config_seguridad" [label="null_resource.config_seguridad", color=red]
+    "terraform_remote_state.network" -> "null_resource.config_seguridad" [label="depends_on"]
+    "null_resource.config_logging" [label="null_resource.config_logging", color=purple]
+    "null_resource.config_monitoreo" [label="null_resource.config_monitoreo", color=yellow]
+    "null_resource.config_compute" [label="null_resource.config_compute", color=green]
+    "null_resource.red_config" [label="null_resource.red_config", color=blue]
+}


### PR DESCRIPTION
En este PR se añade el método `get_module_color(module_name)` para asignar colores a cada módulo en el grafo generado en formato DOT. Con el método obtenemos los colores los cuales fueron asignados del siguiente modo
```py
color_map = {
        'network': 'blue',
        'compute': 'green', 
        'storage': 'orange',
        'security': 'red',
        'logging': 'purple',
        'monitoring': 'yellow'
    }
```
Luego se agrega a los nodos las aristas con los respectivos colores, además de labels indicando el módulo correspondiente.
En el archivo `diagrama_red.dot`, el cual fue generado, podrán corroborar las modificaciones de esta implementación. Adicionalmente los invito a corroborar manualmente ejecutando el script con el siguiente comando
```bash
python3 scripts/generar_diagrama.py
```