### PR TITLE
Feature/docs diagram svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,20 +144,20 @@ El archivo índice generado automáticamente proporciona:
 
 En el archivo `diagrama_red.svg` se logra vizualizar las dependencias entre los modulos de terraform que se tiene siguiendo las siguientes conveciones.
 
-#### Colores por Modulo
+#### **Colores por Modulo**
 
-- Azul: compute
-- Verde: logging
-- Naranja: monitoreo
-- Rojo: network
-- Purpura: seguridad
-- Amarillo: almacenamiento
+- **Azul**: compute
+- **Verde**: logging
+- **Naranja**: monitoreo
+- **Rojo**: network
+- **Purpura**: seguridad
+- **Amarillo**: almacenamiento
 
-#### Conexiones y Etiquetas
+#### **Conexiones y Etiquetas**
 
-- Flechas: Indica la dependencia entre recursos
-- Etiqueta "depends_on": Muestra que un recurso depende de otro
-- Dirección: La flecha que apunta desde la dependencia hacia el recurso dependiente
+- **Flechas**: Indica la dependencia entre recursos
+- **Etiqueta "depends_on"**: Muestra que un recurso depende de otro
+- **Dirección**: La flecha que apunta desde la dependencia hacia el recurso dependiente
 
 ## 3. Instrucciones básicas de reproducibilidad:
 
@@ -214,6 +214,54 @@ python3 scripts/verificar_nomenclatura.py
 # Solo generar el archivo svg a partir de el archivo diagrama_red.dot
 dot -Tsvg docs/diagrama_red.dot -o docs/diagrama_red.svg
 
+```
+
+
+### Convenciones de Nomenclatura para Módulos
+
+El script `verificar_nomenclatura.py` valida que los nombres de módulos en `iac/` cumplan con el patrón establecido: `^[a-z][a-z0-9_]+$`
+
+#### **Ejemplos de nombres CORRECTOS:**
+```
+compute          # OK: minúsculas
+storage          # OK: minúsculas
+network          # OK: minúsculas
+monitoring       # OK: minúsculas
+security         # OK: minúsculas
+logging          # OK: minúsculas
+api_gateway      # OK: minúsculas con guión bajo
+data_pipeline    # OK: minúsculas con guión bajo
+web_server       # OK: minúsculas con guión bajo
+database_primary # OK: minúsculas con guión bajo
+cache_redis      # OK: minúsculas con guión bajo
+load_balancer    # OK: minúsculas con guión bajo
+backup_s3        # OK: minúsculas con números y guión bajo
+```
+
+#### **Ejemplos de nombres INCORRECTOS:**
+```
+Compute          # ERROR: Contiene mayúsculas
+STORAGE          # ERROR: Todo en mayúsculas
+Network-VPC      # ERROR: Contiene guión (-)
+api.gateway      # ERROR: Contiene punto (.)
+_monitoring      # ERROR: Comienza con guión bajo
+9security        # ERROR: Comienza con número
+web server       # ERROR: Contiene espacio
+database@prod    # ERROR: Contiene carácter especial (@)
+load-balancer    # ERROR: Contiene guión (-)
+API_Gateway      # ERROR: Contiene mayúsculas
+```
+
+#### **Reglas de nomenclatura:**
+- Debe comenzar con una letra minúscula (`a-z`)
+- Puede contener letras minúsculas, números y guiones bajos (`a-z`, `0-9`, `_`)
+- No puede contener mayúsculas, guiones (-), puntos (.), espacios o caracteres especiales
+- No puede comenzar con números o guiones bajos
+
+#### **Verificación:**
+```bash
+# Validar nomenclatura de todos los módulos
+python3 scripts/verificar_nomenclatura.py
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ El archivo índice generado automáticamente proporciona:
 
 
 ## 3. Instrucciones básicas de reproducibilidad:
+
 Aunque no haya aún una funcionalidad establecida, es posible acceder a este proyecto mediante los siguientes pasos:
 ```bash
 # 1. Clonar el repositorio
@@ -150,11 +151,24 @@ cd PracticaCalificada3_Grupo5
 # 2. Verificar nomenclatura de módulos (opcional)
 python3 scripts/verificar_nomenclatura.py
 
-# 3. Ejecutar el proceso completo de documentación
+# 3.Instalación de Graphviz
+
+Dado que el proyecto corre en linux instalaremos la dependencia mediante los siguientes comando pues solo usando esta dependencia podremos crear el SVG a partir del archivo .dot generado
+
+# Debian / Ubuntu
+
+sudo apt update
+sudo apt install graphviz
+
+# Arch Linux / Manjaro
+
+sudo pacman -S graphviz
+
+# 4. Ejecutar el proceso completo de documentación
 chmod +x scripts/update_docs.sh
 ./scripts/update_docs.sh
 
-# 4. Ver la documentación generada
+# 5. Ver la documentación generada
 cd docs/
 ls -la  # Verás todos los archivos .md generados
 ```
@@ -163,6 +177,9 @@ ls -la  # Verás todos los archivos .md generados
 - `docs/index.md` - Índice principal con enlaces a todos los módulos
 - `docs/<módulo>.md` - Documentación individual de cada módulo
 - `docs/diagrama_red.dot` - Diagrama de red en formato DOT
+- `docs/diagrama_red.svg` - Diagrama de red en formato SVG
+
+
 
 ### Ejecución individual de componentes:
 ```bash
@@ -174,6 +191,10 @@ python3 scripts/generar_diagrama.py
 
 # Solo verificar nomenclatura
 python3 scripts/verificar_nomenclatura.py
+
+# Solo generar el archivo svg a partir de el archivo diagrama_red.dot
+dot -Tsvg docs/diagrama_red.dot -o docs/diagrama_red.svg
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,25 @@ El archivo índice generado automáticamente proporciona:
 - Estructura de navegación centralizada para acceso directo a cualquier módulo
 
 
+### Interpretacion del Diagrama de Red
+
+En el archivo `diagrama_red.svg` se logra vizualizar las dependencias entre los modulos de terraform que se tiene siguiendo las siguientes conveciones.
+
+#### Colores por Modulo
+
+- Azul: compute
+- Verde: logging
+- Naranja: monitoreo
+- Rojo: network
+- Purpura: seguridad
+- Amarillo: almacenamiento
+
+#### Conexiones y Etiquetas
+
+- Flechas: Indica la dependencia entre recursos
+- Etiqueta "depends_on": Muestra que un recurso depende de otro
+- Dirección: La flecha que apunta desde la dependencia hacia el recurso dependiente
+
 ## 3. Instrucciones básicas de reproducibilidad:
 
 Aunque no haya aún una funcionalidad establecida, es posible acceder a este proyecto mediante los siguientes pasos:


### PR DESCRIPTION
Añadir a la documentacion el como Instalar Graphviz para poder generar el `diagrama_red.svg` a partir de `diagrama_red.dot` y como este esta  integrado dentro del script `generar_diagrama.py`, ademas se añadio documentacion acerca de las conveciones de colores, etiquetas y flechas usadas en el digrama, por ultimo se añadio ejemplos valido e invalidos de como deberia de nombrar los modulos dentro de `iac/**`

![{47E296B7-2BED-4D70-90B2-40C1364E87B2}](https://github.com/user-attachments/assets/861e521d-8502-4b92-87b6-e416bceac4fb)
