### PR TITLE
fix(scripts): corregir orden de limpieza de módulos en update_docs.sh

### DIFF
--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -32,7 +32,7 @@ python3 scripts/generar_diagrama.py
 
 # Limpiar de archivos realizando terraform destroy en cada modulo
 echo "Iniciando limpieza de recursos de cada modulo..."
-for modulo_dir in iac/*/; do
+for modulo_dir in $(ls -1d iac/*/ | sort -r); do
     if [ -d "$modulo_dir" ]; then
         echo "Destruyendo recursos en $modulo_dir"
         cd "$modulo_dir" 


### PR DESCRIPTION
Una pequeña correccion en el orden de ejecucion de `terraform destroy` para que no ocurra problemas de las dependencias al momento de ejecucion en el script `update_docs.sh`